### PR TITLE
Tweak text in api.html, remove latest

### DIFF
--- a/sjs2/doc/api.html
+++ b/sjs2/doc/api.html
@@ -61,22 +61,12 @@
         <div class="col-md-9">
             <h2 id="a-nameapia-api"><a name="api"></a> API</h2>
 
-<p>Generated Scaladocs are available here:</p>
+<p>
+    This page contains the generated API documentation for the core Scala.js
+    project and libraries
+</p>
 
 <h3 id="scalajs">Scala.js</h3>
-
-<h4 id="latest">Latest</h4>
-
-<ul>
-  <li><a href="http://www.scala-js.org/api/scalajs-library/latest/#scala.scalajs.js.package">scalajs-library</a></li>
-  <li><a href="http://www.scala-js.org/api/sbt-scalajs/latest/#org.scalajs.sbtplugin.package">sbt-scalajs</a></li>
-  <li><a href="http://www.scala-js.org/api/scalajs-test-interface/latest/">scalajs-test-interface</a></li>
-  <li><a href="http://www.scala-js.org/api/scalajs-stubs/latest/">scalajs-stubs</a></li>
-  <li><a href="http://www.scala-js.org/api/scalajs-ir/latest/#org.scalajs.core.ir.package">scalajs-ir</a></li>
-  <li><a href="http://www.scala-js.org/api/scalajs-tools/latest/#org.scalajs.core.tools.package">scalajs-tools</a> (<a href="http://www.scala-js.org/api/scalajs-tools-js/latest/#org.scalajs.core.tools.package">Scala.js version</a>)</li>
-  <li><a href="http://www.scala-js.org/api/scalajs-js-envs/latest/#org.scalajs.jsenv.package">scalajs-js-envs</a></li>
-  <li><a href="http://www.scala-js.org/api/scalajs-sbt-test-adapter/latest/#org.scalajs.testadapter.package">scalajs-test-adapter</a></li>
-</ul>
 
 <h4 id="scalajs-065">Scala.js 0.6.5</h4>
 <ul>


### PR DESCRIPTION
The links in `Latest` are all broken. Easy to just leave them out, it's obvious that 0.6.5 is the latest looking at this page =P
