### PR TITLE
Tweak code style in index.html to match convention

### DIFF
--- a/sjs2/index.html
+++ b/sjs2/index.html
@@ -172,10 +172,10 @@ Person.prototype.sayHello = function(target) {
         </div>
         <div class="col-md-6">
             <h6 class="text-right">Scala.js</h6>
-                    <pre><code class="scala">class Person(firstName:String) {
+                    <pre><code class="scala">class Person(firstName: String) {
   def walk = println("I am walking!")
 
-  def sayHello(target:String) =
+  def sayHello(target: String) =
     println(s"Hello $target, I'm $firstName")
 }</code></pre>
         </div>
@@ -203,22 +203,29 @@ val names = persons.map(_.firstName)</code></pre>
         </div>
         <div class="col-md-6">
             <h6 class="text-right">JavaScript</h6>
-                    <pre><code class="javascript">var personMap = {"10": new Person("Roger Moore"),
-    "20": new Person("James Bond")};
+                    <pre><code class="javascript">
+var personMap = {
+    "10": new Person("Roger Moore"),
+    "20": new Person("James Bond")
+};
 var names = [];
 for(var key in personMap) {
     if(Object.prototype.hasOwnProperty.call(names, key)) {
         if(parseInt(key) > 15) {
-            names.push(key +
-                " = " + personMap[key].firstName;
+            names.push(
+                key + " = " + personMap[key].firstName
+            );
         }
     }
 }</code></pre>
         </div>
         <div class="col-md-6">
             <h6 class="text-right">Scala.js</h6>
-                    <pre><code class="scala">val personMap = Map(10 -> new Person("Roger Moore"),
-  20 -> new Person("James Bond"));
+                    <pre><code class="scala">
+val personMap = Map(
+  10 -> new Person("Roger Moore"),
+  20 -> new Person("James Bond")
+);
 val names = for {
   (key, person) <- personMap
   if key > 15


### PR DESCRIPTION
Makes the code just a wee bit more idiomatic.

Also fix a missing paren in JS example
