### PR TITLE
Update index.html

### DIFF
--- a/scala-js-website/index.html
+++ b/scala-js-website/index.html
@@ -10,7 +10,7 @@ permalink: /
                 <img width="128" src="{{ '/assets/img/scala-js-logo.svg' | prepend: site.baseurl }}">
 
                 <div>
-                    <h4>The most powerful server side programming language<br/> now available on the frontend!</h4>
+                    <h4>A safer way to build complex, bug-free<br/> front-end web applications!</h4>
                 </div>
                 <div>
                     <a class="btn btn-theme" href="{{ site.baseurl }}/tutorial">Learn in 15 mins</a>
@@ -40,7 +40,7 @@ permalink: /
             <div class="col-md-4">
                 <div class="center-align">
                     <i class="fa fa-rocket"></i>
-                    <h4>Performance</h4>
+                    <h4><a href="{{ site.baseurl}}/doc/internals/compile-opt-pipeline.html">Performance</a></h4>
                 </div>
                 Scala.js compiles Scala code into highly efficient JavaScript utilizing an internal optimizer.
                 Incremental compilation guarantees speedy (1-2s) turn-around times when your code changes. 


### PR DESCRIPTION
- Change the tag line; the previous one appeals to Scala people more, where-as now we want to target the JS audience
- Turn "Performance" into a link to the compilation pipeline page. Maybe someday we'll convince @sjrd to write-up something nice.
