### PR TITLE
Paranteses needed for ES6

### DIFF
--- a/scala-js-website/doc/sjs_for_js/es6_to_scala_part3.md
+++ b/scala-js-website/doc/sjs_for_js/es6_to_scala_part3.md
@@ -310,7 +310,7 @@ class_.
 String.prototype.toDate = function() {
   return convertToDate(this);
 }
-"2015-10-09".toDate; // = {year:2015,month:10,day:9}
+"2015-10-09".toDate(); // = {year:2015,month:10,day:9}
 {% endhighlight %}
 {% endcolumn %}
         


### PR DESCRIPTION
Seems like .toDate will just return the function and not call it, so add ()